### PR TITLE
Fixes #7

### DIFF
--- a/StaticGroupFromSearch.py
+++ b/StaticGroupFromSearch.py
@@ -124,6 +124,7 @@ class JSS(object):
     def request(self, request):
         request.add_header('Authorization', 'Basic ' + self.auth)
         request.add_header('Content-Type', 'text/xml')
+        request.add_header('accept', 'text/xml')
         try:
             response = urllib2.urlopen(request)
         except ValueError as e:

--- a/StaticGroupFromSearch.py
+++ b/StaticGroupFromSearch.py
@@ -124,7 +124,7 @@ class JSS(object):
     def request(self, request):
         request.add_header('Authorization', 'Basic ' + self.auth)
         request.add_header('Content-Type', 'text/xml')
-        request.add_header('accept', 'text/xml')
+        request.add_header('Accept', 'text/xml')
         try:
             response = urllib2.urlopen(request)
         except ValueError as e:


### PR DESCRIPTION
If the accept is not specified, the server returns it's configured payload. This is usually text, to fix the issue described, I added the accept: text/xml header to make the server send the payload in xml format.